### PR TITLE
Investigate profile upload rls policy errors

### DIFF
--- a/PROFILE_UPLOAD_FIX.md
+++ b/PROFILE_UPLOAD_FIX.md
@@ -1,0 +1,121 @@
+# Profile Upload RLS Policy Fix
+
+## Problem Summary
+
+Profile image uploads were failing with "new row violates RLS policy" errors due to multiple conflicting migration files that created inconsistent Row Level Security (RLS) policies.
+
+## Root Causes Identified
+
+1. **Conflicting Migration Files**: Three different migrations (11, 12, and 14) created conflicting RLS policies
+2. **Incomplete UPDATE Policy**: Migration 11 had a syntax error missing the `(auth.uid() = id) OR` condition on line 47
+3. **Different Storage Policy Patterns**: Migration 12 used `LIKE auth.uid()::text || '/%'` while migration 14 used `(storage.foldername(name))[1]`
+4. **Overwritten Profile Policies**: Migration 14 completely replaced crucial profile table policies from migration 11
+
+## Solution
+
+Created a comprehensive migration `20250103000015_fix_profile_upload_rls_final.sql` that:
+
+✅ **Consolidates all conflicting policies**
+✅ **Fixes the broken UPDATE policy syntax**
+✅ **Uses consistent storage policy patterns**
+✅ **Ensures both profiles table and storage bucket policies work together**
+✅ **Maintains admin permissions and role escalation protection**
+
+## How to Apply the Fix
+
+### Option 1: Using Supabase CLI (Recommended)
+
+```bash
+# Navigate to your project directory
+cd /workspace
+
+# Apply the migration
+supabase db push
+
+# Or if you want to see what will be applied first:
+supabase db diff
+```
+
+### Option 2: Manual Application via Supabase Dashboard
+
+1. Go to your Supabase Dashboard
+2. Navigate to **SQL Editor**
+3. Copy the contents of `supabase/migrations/20250103000015_fix_profile_upload_rls_final.sql`
+4. Paste and execute the SQL
+
+### Option 3: Reset and Apply All Migrations
+
+If you have persistent issues:
+
+```bash
+# Reset the database (WARNING: This will delete all data)
+supabase db reset
+
+# This will reapply all migrations in order, including the fix
+```
+
+## Verification Steps
+
+After applying the migration, test the profile upload functionality:
+
+1. **Test Authentication**: Ensure you're logged in
+2. **Test Profile Update**: Try updating your profile information
+3. **Test Image Upload**: Upload a profile image
+4. **Check Console**: Look for success messages without RLS errors
+
+### Debug Commands
+
+If you still have issues, run these in your browser console:
+
+```javascript
+// Test storage connectivity (available in your utils)
+import { testProfileImageConnection } from '@/utils/testProfileImageConnection';
+await testProfileImageConnection();
+
+// Debug storage setup
+import { debugProfileImageStorage } from '@/utils/profileImageDebug';
+await debugProfileImageStorage();
+```
+
+## File Path Structure
+
+The fix ensures images are stored with this structure:
+```
+profile-images/
+  ├── {user-id-1}/
+  │   └── profile-{timestamp}.{ext}
+  ├── {user-id-2}/
+  │   └── profile-{timestamp}.{ext}
+  └── ...
+```
+
+## RLS Policies Created
+
+### Profiles Table
+- **SELECT**: Users can view their own profile + Admins can view all
+- **UPDATE**: Users can update their own profile + Admins can update any
+- **INSERT**: Users can create their own profile + Admins can create any
+- **DELETE**: Only admins can delete profiles (not their own)
+
+### Storage Objects (profile-images bucket)
+- **SELECT**: Public can view all profile images
+- **INSERT**: Users can upload to their own folder only
+- **UPDATE**: Users can update their own images only
+- **DELETE**: Users can delete their own images only
+- **ALL (Admin)**: Admins can manage all profile images
+
+## Security Features Maintained
+
+✅ **User Isolation**: Users can only access their own profile images
+✅ **Admin Override**: Admins can manage all profiles and images
+✅ **Role Protection**: Users cannot escalate their own roles
+✅ **Public Display**: Profile images are viewable for UI display
+
+## Migration File Details
+
+- **File**: `supabase/migrations/20250103000015_fix_profile_upload_rls_final.sql`
+- **Date**: 2025-01-03
+- **Purpose**: Comprehensive fix for all profile upload RLS issues
+- **Safe**: Uses `IF EXISTS` and `IF NOT EXISTS` clauses to prevent conflicts
+
+The migration will work whether you have an existing setup or are starting fresh.

--- a/supabase/migrations/20250103000015_fix_profile_upload_rls_final.sql
+++ b/supabase/migrations/20250103000015_fix_profile_upload_rls_final.sql
@@ -1,0 +1,180 @@
+-- Fix profile upload RLS policy violations
+-- This migration consolidates and fixes all profile image related RLS policies
+-- Date: 2025-01-03 (Final Fix)
+
+-- PART 1: FIX PROFILES TABLE RLS POLICIES
+-- =====================================
+
+-- Drop all existing conflicting policies
+DROP POLICY IF EXISTS "Profile view policy" ON public.profiles;
+DROP POLICY IF EXISTS "Profile update policy" ON public.profiles;
+DROP POLICY IF EXISTS "Profile insert policy" ON public.profiles;
+DROP POLICY IF EXISTS "Profile delete policy" ON public.profiles;
+DROP POLICY IF EXISTS "Users can update their own profile" ON public.profiles;
+DROP POLICY IF EXISTS "Users can view all profiles" ON public.profiles;
+DROP POLICY IF EXISTS "Admins can manage all profiles" ON public.profiles;
+
+-- Ensure the helper function exists
+CREATE OR REPLACE FUNCTION public.is_user_admin(user_id UUID DEFAULT auth.uid())
+RETURNS BOOLEAN AS $$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1 FROM public.profiles 
+    WHERE id = user_id AND role = 'admin'
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE;
+
+-- Grant execute permissions
+GRANT EXECUTE ON FUNCTION public.is_user_admin(UUID) TO authenticated;
+
+-- Create comprehensive profiles table RLS policies
+CREATE POLICY "Profiles SELECT policy" ON public.profiles
+FOR SELECT TO authenticated
+USING (
+  auth.uid() = id OR 
+  public.is_user_admin()
+);
+
+CREATE POLICY "Profiles UPDATE policy" ON public.profiles
+FOR UPDATE TO authenticated
+USING (
+  auth.uid() = id OR 
+  public.is_user_admin()
+) WITH CHECK (
+  auth.uid() = id OR 
+  public.is_user_admin()
+);
+
+CREATE POLICY "Profiles INSERT policy" ON public.profiles
+FOR INSERT TO authenticated
+WITH CHECK (
+  auth.uid() = id OR 
+  public.is_user_admin()
+);
+
+CREATE POLICY "Profiles DELETE policy" ON public.profiles
+FOR DELETE TO authenticated
+USING (
+  public.is_user_admin() AND auth.uid() != id
+);
+
+-- PART 2: FIX STORAGE BUCKET RLS POLICIES
+-- =======================================
+
+-- Ensure the profile-images bucket exists
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM storage.buckets WHERE name = 'profile-images') THEN
+        INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+        VALUES ('profile-images', 'profile-images', false, 5242880, ARRAY['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+    END IF;
+END $$;
+
+-- Enable RLS on storage.objects
+ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
+
+-- Drop all existing conflicting storage policies
+DROP POLICY IF EXISTS "Users can view profile images" ON storage.objects;
+DROP POLICY IF EXISTS "Users can upload their own profile images" ON storage.objects;
+DROP POLICY IF EXISTS "Users can update their own profile images" ON storage.objects;
+DROP POLICY IF EXISTS "Users can delete their own profile images" ON storage.objects;
+DROP POLICY IF EXISTS "Public can view profile images" ON storage.objects;
+DROP POLICY IF EXISTS "Admins can manage all profile images" ON storage.objects;
+
+-- Create consistent storage policies using the foldername approach
+-- Policy 1: Allow public viewing of profile images
+CREATE POLICY "Profile images public view" ON storage.objects
+FOR SELECT USING (
+    bucket_id = 'profile-images'
+);
+
+-- Policy 2: Allow authenticated users to upload their own profile images
+CREATE POLICY "Profile images user upload" ON storage.objects
+FOR INSERT TO authenticated
+WITH CHECK (
+    bucket_id = 'profile-images' AND 
+    auth.uid()::text = (storage.foldername(name))[1]
+);
+
+-- Policy 3: Allow authenticated users to update their own profile images
+CREATE POLICY "Profile images user update" ON storage.objects
+FOR UPDATE TO authenticated
+USING (
+    bucket_id = 'profile-images' AND 
+    auth.uid()::text = (storage.foldername(name))[1]
+) WITH CHECK (
+    bucket_id = 'profile-images' AND 
+    auth.uid()::text = (storage.foldername(name))[1]
+);
+
+-- Policy 4: Allow authenticated users to delete their own profile images
+CREATE POLICY "Profile images user delete" ON storage.objects
+FOR DELETE TO authenticated
+USING (
+    bucket_id = 'profile-images' AND 
+    auth.uid()::text = (storage.foldername(name))[1]
+);
+
+-- Policy 5: Allow admins to manage all profile images
+CREATE POLICY "Profile images admin manage" ON storage.objects
+FOR ALL TO authenticated
+USING (
+    bucket_id = 'profile-images' AND 
+    public.is_user_admin()
+) WITH CHECK (
+    bucket_id = 'profile-images' AND 
+    public.is_user_admin()
+);
+
+-- PART 3: ENSURE PROPER TABLE SETUP
+-- =================================
+
+-- Ensure RLS is enabled on both tables
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
+
+-- Ensure profile_image_url column exists
+ALTER TABLE public.profiles 
+ADD COLUMN IF NOT EXISTS profile_image_url TEXT;
+
+-- Add comment to document the column
+COMMENT ON COLUMN public.profiles.profile_image_url IS 'URL to user profile image stored in Supabase Storage';
+
+-- Create index for better performance
+CREATE INDEX IF NOT EXISTS idx_profiles_profile_image_url ON public.profiles(profile_image_url) WHERE profile_image_url IS NOT NULL;
+
+-- PART 4: ROLE ESCALATION PROTECTION
+-- ==================================
+
+-- Ensure role escalation prevention trigger exists
+CREATE OR REPLACE FUNCTION public.prevent_role_escalation()
+RETURNS trigger AS $$
+BEGIN
+  -- If a non-admin user is trying to change their role, prevent it
+  IF OLD.id = auth.uid() AND OLD.role != NEW.role AND NOT public.is_user_admin() THEN
+    RAISE EXCEPTION 'Users cannot change their own role';
+  END IF;
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Drop existing trigger if it exists
+DROP TRIGGER IF EXISTS prevent_role_escalation_trigger ON public.profiles;
+
+-- Create the trigger
+CREATE TRIGGER prevent_role_escalation_trigger
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.prevent_role_escalation();
+
+-- Grant necessary permissions
+GRANT EXECUTE ON FUNCTION public.prevent_role_escalation() TO authenticated;
+
+-- PART 5: VERIFICATION QUERIES (FOR TESTING)
+-- ==========================================
+
+-- These are commented out but can be run manually to verify the fix
+-- SELECT policy_name, policy_definition FROM pg_policies WHERE tablename = 'profiles';
+-- SELECT policy_name, policy_definition FROM pg_policies WHERE tablename = 'objects' AND policy_definition LIKE '%profile-images%';


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes RLS policies to enable profile image uploads by resolving conflicts and correcting syntax errors in existing migrations.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Profile uploads were failing with RLS violations because multiple previous migration files (11, 12, 14) introduced conflicting and syntactically incorrect RLS policies for both the `profiles` table and the `profile-images` storage bucket. This PR consolidates, corrects, and harmonizes these policies to ensure proper user and admin access for profile management and image uploads.

---
<a href="https://cursor.com/background-agent?bcId=bc-604b4a4f-f198-474a-8d0d-b1ff91850750">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-604b4a4f-f198-474a-8d0d-b1ff91850750">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>